### PR TITLE
Remove use of deprecated patterns function

### DIFF
--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,11 +1,11 @@
 from django.conf import settings
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 
 from testproject import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Examples:
     # url(r'^$', 'testproject.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
@@ -13,4 +13,4 @@ urlpatterns = patterns('',
     url(r'^admin/', include(admin.site.urls)),
     url(r'^$', views.TestView.as_view(), name='home'),
     url(r'^groups-manager/', include('groups_manager.urls', namespace='groups_manager')),
-) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
`django.conf.urls.patterns()` was [deprecated in Django 1.8](https://docs.djangoproject.com/en/1.10/releases/1.8/#django-conf-urls-patterns) and [deleted in Django 1.10](https://docs.djangoproject.com/en/1.10/releases/1.10/#features-removed-in-1-10)