### PR TITLE
Fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pip install django-groups-manager
 
     ```python
     GROUPS_MANAGER = {
-        'DJANGO_AUTH_SYNC': True,
+        'AUTH_MODELS_SYNC': True,
     }
     ```
 


### PR DESCRIPTION
The readme currently incorrectly states that `DJANGO_AUTH_SYNC` instead of `AUTH_MODELS_SYNC` should be used to enable `auth.models` synchronization