### PR TITLE
Fix import of models in forms

### DIFF
--- a/groups_manager/forms.py
+++ b/groups_manager/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-import models
+from groups_manager import models
 
 
 class MemberForm(forms.ModelForm):


### PR DESCRIPTION
Relative imports are not available in Python 3 with the `import` statement: https://docs.python.org/release/3.0.1/whatsnew/3.0.html#removed-syntax

This fixes the failed travis build in #10 