### PR TITLE
Add option to restrict permissions to group types

### DIFF
--- a/docs/source/permissions_by_group_type.rst
+++ b/docs/source/permissions_by_group_type.rst
@@ -1,0 +1,72 @@
+.. _custom-permissions-by-group-type:
+
+Resource assignment via group type permissions
+----------------------------------------
+
+Permissions can also be applied to related groups filtered by group types.
+Instead of simply using a list to specify permissions one can use a ``dict`` to
+specify which group types get which permissions.
+
+
+Example
+#######
+
+
+John Money is the commercial referent of the company; Patrick Html is the web
+developer. John and Patrick can view the site, but only Patrick can change and
+delete it.
+
+**1) Define models in models.py**::
+
+    class Site(Group):
+        name = models.CharField(max_length=100)
+
+        class Meta:
+            permissions = (('view_site', 'View site'),
+                           ('sell_site', 'Sell site'), )
+
+**2) Create models and relations**::
+
+    from groups_manager.models import Group, GroupType, Member
+    from models import Site
+
+    # Parent Group
+    company = Group.objects.create(name='Company')
+
+    # Group Types
+    developer = GroupType.objects.create(label='developer')
+    referent = GroupType.objects.create(label='referent')
+
+    # Child groups
+    developers = Group.objects.create(name='Developers', group_type=developer, parent=company)
+    referents = Group.objects.create(name='Referents', group_type=referent, parent=company)
+
+    # Members
+    john = Member.objects.create(first_name='John', last_name='Money')
+    patrick = Member.objects.create(first_name='Patrick', last_name='Html')
+
+    # Add to groups
+    referents.add_member(john)
+    developers.add_member(patrick)
+
+    # Create the site
+    site = Site.objects.create(name='Django groups manager website')
+
+**3) Define custom permissions and assign the site object**::
+
+    custom_permissions = {
+        'owner': [],
+        'group': ['view'],
+        'groups_downstream': {'developer': ['change', 'delete'], 'default': ['view']},
+    }
+    john.assign_object(company, site, custom_permissions=custom_permissions)
+
+**4) Check permissions**::
+
+    john.has_perm('view_site', site)  # True
+    john.has_perm('change_site', site)  # False
+    john.has_perm('delete_site', site)  # False
+    patrick.has_perms(['view_site', 'change_site', 'delete_site'], site)  # True
+
+.. note::
+ The full tested example is available in repository source code, ``testproject``'s ``tests.py`` under ``test_group_types_permissions`` method.

--- a/docs/source/use_cases.rst
+++ b/docs/source/use_cases.rst
@@ -7,6 +7,8 @@ Use cases
 
 .. include:: permissions_by_role.rst
 
+.. include:: permissions_by_group_type.rst
+
 .. include:: custom_member.rst
 
 .. include:: custom_signals.rst

--- a/groups_manager/perms.py
+++ b/groups_manager/perms.py
@@ -10,11 +10,27 @@ from groups_manager.utils import get_permission_name
 
 
 def assign_related(related_groups, perms, obj):
-    for group in related_groups:
-        django_group = group.django_group
-        for permission in list(set(perms)):
-            perm_name = get_permission_name(permission, obj)
-            assign_perm(perm_name, django_group, obj)
+    if isinstance(perms, dict):
+        default = set(perms.pop('default', []))
+
+        for group in related_groups:
+            django_group = group.django_group
+
+            for permission in default:
+                perm_name = get_permission_name(permission, obj)
+                assign_perm(perm_name, django_group, obj)
+
+            if group.group_type is not None:
+                for permission in set(perms.get(group.group_type.codename, [])):
+                    perm_name = get_permission_name(permission, obj)
+                    assign_perm(perm_name, django_group, obj)
+
+    else:
+        for group in related_groups:
+            django_group = group.django_group
+            for permission in list(set(perms)):
+                perm_name = get_permission_name(permission, obj)
+                assign_perm(perm_name, django_group, obj)
 
 
 def assign_object_to_member(group_member, obj, **kwargs):

--- a/groups_manager/perms.py
+++ b/groups_manager/perms.py
@@ -9,6 +9,14 @@ except ImportError:
 from groups_manager.utils import get_permission_name
 
 
+def assign_related(related_groups, perms, obj):
+    for group in related_groups:
+        django_group = group.django_group
+        for permission in list(set(perms)):
+            perm_name = get_permission_name(permission, obj)
+            assign_perm(perm_name, django_group, obj)
+
+
 def assign_object_to_member(group_member, obj, **kwargs):
     """Assign an object to a GroupMember instance object.
 
@@ -41,28 +49,21 @@ def assign_object_to_member(group_member, obj, **kwargs):
         for permission in list(set(group_perms)):
             perm_name = get_permission_name(permission, obj)
             assign_perm(perm_name, group_member.group.django_group, obj)
+
         # groups_upstream
-        upstream_groups = [group.django_group for group in group_member.group.get_ancestors()]
+        upstream_groups = group_member.group.get_ancestors()
         upstream_perms = permissions.get('groups_upstream', [])
-        for django_group in upstream_groups:
-            for permission in list(set(upstream_perms)):
-                perm_name = get_permission_name(permission, obj)
-                assign_perm(perm_name, django_group, obj)
+        assign_related(upstream_groups, upstream_perms, obj)
+
         # groups_downstream
-        downstream_groups = \
-            [group.django_group for group in group_member.group.get_descendants()]
+        downstream_groups = group_member.group.get_descendants()
         downstream_perms = permissions.get('groups_downstream', [])
-        for django_group in downstream_groups:
-            for permission in list(set(downstream_perms)):
-                perm_name = get_permission_name(permission, obj)
-                assign_perm(perm_name, django_group, obj)
+        assign_related(downstream_groups, downstream_perms, obj)
+
         # groups_siblings
-        siblings_groups = [group.django_group for group in group_member.group.get_siblings()]
+        siblings_groups = group_member.group.get_siblings()
         siblings_perms = permissions.get('groups_siblings', [])
-        for django_group in siblings_groups:
-            for permission in list(set(siblings_perms)):
-                perm_name = get_permission_name(permission, obj)
-                assign_perm(perm_name, django_group, obj)
+        assign_related(siblings_groups, siblings_perms, obj)
 
 
 def assign_object_to_group(group, obj, **kwargs):
@@ -85,25 +86,18 @@ def assign_object_to_group(group, obj, **kwargs):
         for permission in list(set(group_perms)):
             perm_name = get_permission_name(permission, obj)
             assign_perm(perm_name, group.django_group, obj)
+
         # groups_upstream
-        upstream_groups = [ancestor_group.django_group for ancestor_group in group.get_ancestors()]
+        upstream_groups = group.get_ancestors()
         upstream_perms = permissions.get('groups_upstream', [])
-        for django_group in upstream_groups:
-            for permission in list(set(upstream_perms)):
-                perm_name = get_permission_name(permission, obj)
-                assign_perm(perm_name, django_group, obj)
+        assign_related(upstream_groups, upstream_perms, obj)
+
         # groups_downstream
-        downstream_groups = \
-            [downstream_group.django_group for downstream_group in group.get_descendants()]
+        downstream_groups = group.get_descendants()
         downstream_perms = permissions.get('groups_downstream', [])
-        for django_group in downstream_groups:
-            for permission in list(set(downstream_perms)):
-                perm_name = get_permission_name(permission, obj)
-                assign_perm(perm_name, django_group, obj)
+        assign_related(downstream_groups, downstream_perms, obj)
+
         # groups_siblings
-        siblings_groups = [sibling_group.django_group for sibling_group in group.get_siblings()]
+        siblings_groups = group.get_siblings()
         siblings_perms = permissions.get('groups_siblings', [])
-        for django_group in siblings_groups:
-            for permission in list(set(siblings_perms)):
-                perm_name = get_permission_name(permission, obj)
-                assign_perm(perm_name, django_group, obj)
+        assign_related(siblings_groups, siblings_perms, obj)

--- a/testproject/testproject/tests.py
+++ b/testproject/testproject/tests.py
@@ -214,12 +214,10 @@ class TestPermissions(TestCase):
 
         john = models.Member.objects.create(first_name='John', last_name='Money')
         patrick = models.Member.objects.create(first_name='Patrick', last_name='Html')
-        company.add_member(john)
-        company.add_member(patrick)
         referents.add_member(john)
         developers.add_member(patrick)
         site = testproject_models.Site.objects.create(name='Django groups manager website')
-        john.assign_object(company, site, custom_permissions=custom_permissions)
+        company.assign_object(site, custom_permissions=custom_permissions)
 
         self.assertTrue(john.has_perm('view_site', site))
         self.assertFalse(john.has_perm('change_site', site))


### PR DESCRIPTION
This allows us to specify which types of groups related to the base group should get the different permissions

```
custom_permissions = {
    'groups_downstream': {'developer': ['change', 'delete'], 'default': ['view']},
}
```