### PR TITLE
Support django-jsonfield

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,17 @@ python:
  - 3.4
 
 env:
- - DJANGO_VERSION="<1.9" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2"
- - DJANGO_VERSION=">=1.9,<2.0" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2"
+ - DJANGO_VERSION="<1.9" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2" JSONFIELD="jsonfield"
+ - DJANGO_VERSION=">=1.9,<2.0" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2" JSONFIELD="jsonfield"
+ - DJANGO_VERSION=">=1.9,<2.0" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2" JSONFIELD="django-jsonfield"
 
 install:
   - pip install -q "Django$DJANGO_VERSION" coverage coveralls
   - pip install "django-guardian$GUARDIAN_VERSION" "django-mptt$MPTT_VERSION"
   - pip install .
   - pip install -r testproject/requirements.txt
+  - pip uninstall jsonfield
+  - pip install "$JSONFIELD"
 
 script:
   - coverage run testproject/manage.py test testproject groups_manager
@@ -24,6 +27,6 @@ after_success:
 matrix:
     include:
         - python: 2.7
-          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8"
+          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8" JSONFIELD="jsonfield"
         - python: 3.4
-          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8"
+          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8" JSONFIELD="jsonfield"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip install "django-guardian$GUARDIAN_VERSION" "django-mptt$MPTT_VERSION"
   - pip install .
   - pip install -r testproject/requirements.txt
-  - pip uninstall jsonfield
+  - pip uninstall -y jsonfield
   - pip install "$JSONFIELD"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,14 @@ python:
  - 3.4
 
 env:
- - DJANGO_VERSION="<1.9" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2" JSONFIELD="jsonfield"
- - DJANGO_VERSION=">=1.9,<2.0" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2" JSONFIELD="jsonfield"
- - DJANGO_VERSION=">=1.9,<2.0" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2" JSONFIELD="django-jsonfield"
+ - DJANGO_VERSION="<1.9" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2"
+ - DJANGO_VERSION=">=1.9,<2.0" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2"
 
 install:
   - pip install -q "Django$DJANGO_VERSION" coverage coveralls
   - pip install "django-guardian$GUARDIAN_VERSION" "django-mptt$MPTT_VERSION"
   - pip install .
   - pip install -r testproject/requirements.txt
-  - pip uninstall -y jsonfield
-  - pip install "$JSONFIELD"
 
 script:
   - coverage run testproject/manage.py test testproject groups_manager
@@ -27,6 +24,6 @@ after_success:
 matrix:
     include:
         - python: 2.7
-          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8" JSONFIELD="jsonfield"
+          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8"
         - python: 3.4
-          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8" JSONFIELD="jsonfield"
+          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8"

--- a/groups_manager/models.py
+++ b/groups_manager/models.py
@@ -325,8 +325,11 @@ class GroupMixin(GroupRelationsMixin, MPTTModel):
     parent = TreeForeignKey('self', null=True, blank=True,
                             related_name='sub_%(app_label)s_%(class)s_set')
     full_name = models.CharField(max_length=255, default='', blank=True)
-    properties = JSONField(default={}, blank=True,
-                            load_kwargs={'object_pairs_hook': OrderedDict})
+    try:
+        properties = JSONField(default={}, blank=True,
+                                load_kwargs={'object_pairs_hook': OrderedDict})
+    except TypeError:
+        properties = JSONField(default={}, blank=True)
 
     django_auth_sync = models.BooleanField(default=True, blank=True)
 


### PR DESCRIPTION
This adds support for both the currently used [`jsonfield`](https://pypi.python.org/pypi/jsonfield) and [`django-jsonfield`](https://pypi.python.org/pypi/django-jsonfield).

Note that `django-jsonfield` does not seem to have any way to specify that the deserialization should be done to a `OrderedDict`. If the sort ordering must be kept on deserialization then `jsonfield` is required.