### PR TITLE
Add Django 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,20 @@
 language: python
 python:
- - 2.7
- - 3.4
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 
-env:
- - DJANGO_VERSION="<1.9" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2"
- - DJANGO_VERSION=">=1.9,<2.0" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2"
+addons:
+  apt:
+    packages:
+      - ruby-coveralls
 
-install:
-  - pip install -q "Django$DJANGO_VERSION" coverage coveralls
-  - pip install "django-guardian$GUARDIAN_VERSION" "django-mptt$MPTT_VERSION"
-  - pip install .
-  - pip install -r testproject/requirements.txt
-
-script:
-  - coverage run testproject/manage.py test testproject groups_manager
+install: pip install tox-travis
+script: tox
 
 after_success:
   - coverage report
   - coveralls
-
-
-matrix:
-    include:
-        - python: 2.7
-          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8"
-        - python: 3.4
-          env: DJANGO_VERSION="<1.8" GUARDIAN_VERSION="<1.4" MPTT_VERSION="<0.8"
-        - python: 3.4
-          env: DJANGO_VERSION=">=2" GUARDIAN_VERSION=">=1.4" MPTT_VERSION="<2"

--- a/groups_manager/views.py
+++ b/groups_manager/views.py
@@ -6,11 +6,15 @@ except ImportError:
     from django.urls import reverse
 
 from django.http import HttpResponseRedirect
-from braces.views import LoginRequiredMixin
 from django.views.generic import ListView, DetailView, CreateView, UpdateView, DeleteView
 from django.views.generic.base import TemplateView
 
 from groups_manager import models, forms, settings
+
+try:
+    from django.contrib.auth.mixins import LoginRequiredMixin
+except ImportError:  # Django 1.8
+    from braces.views import LoginRequiredMixin
 
 TS = settings.GROUPS_MANAGER['TEMPLATE_STYLE']
 if TS:

--- a/testproject/testproject/migrations/0001_initial.py
+++ b/testproject/testproject/migrations/0001_initial.py
@@ -25,6 +25,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_cloudplatform', 'View Cloud Platform'),),
             },
             bases=(models.Model,),
@@ -36,6 +37,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_itobject', 'View IT Object'), ('manage_itobject', 'Manage IT Object')),
             },
             bases=(models.Model,),
@@ -47,6 +49,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_legion', 'View Legion'),),
             },
             bases=(models.Model,),
@@ -57,6 +60,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_match', 'View match'), ('play_match', 'Play match')),
             },
             bases=(models.Model,),
@@ -68,6 +72,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_newsletter', 'View Newsletter'), ('send_newsletter', 'Send Newsletter')),
             },
             bases=(models.Model,),
@@ -193,6 +198,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_pipeline', 'View Pipeline'),),
             },
             bases=(models.Model,),
@@ -203,6 +209,7 @@ class Migration(migrations.Migration):
                 ('group_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='groups_manager.Group', on_delete=models.CASCADE)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_projectgroup', 'View Project Group'),),
             },
             bases=('groups_manager.group',),
@@ -224,6 +231,7 @@ class Migration(migrations.Migration):
                 ('member_ptr', models.OneToOneField(parent_link=True, auto_created=True, primary_key=True, serialize=False, to='groups_manager.Member', on_delete=models.CASCADE)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_projectmember', 'View Project Member'),),
             },
             bases=('groups_manager.member',),
@@ -235,6 +243,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_site', 'View site'), ('sell_site', 'Sell site')),
             },
             bases=(models.Model,),
@@ -246,6 +255,7 @@ class Migration(migrations.Migration):
                 ('name', models.CharField(max_length=100)),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_surfaceproduct', 'View Surface Product'),),
             },
             bases=(models.Model,),
@@ -257,6 +267,7 @@ class Migration(migrations.Migration):
                 ('euros', models.IntegerField()),
             ],
             options={
+                'default_permissions': ('add', 'change', 'delete'),
                 'permissions': (('view_teambudget', 'View team budget'),),
             },
             bases=(models.Model,),

--- a/testproject/testproject/models.py
+++ b/testproject/testproject/models.py
@@ -17,6 +17,7 @@ class Legion(models.Model):
     name = models.CharField(max_length=100)
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_legion', 'View Legion'), )
 
     def __unicode__(self):
@@ -35,6 +36,7 @@ class TeamBudget(models.Model):
     euros = models.IntegerField()
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_teambudget', 'View team budget'), )
 
 
@@ -43,6 +45,7 @@ class Match(models.Model):
     away = models.ForeignKey(Group, related_name='match_away', on_delete=models.CASCADE)
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_match', 'View match'),
                        ('play_match', 'Play match'), )
 
@@ -56,6 +59,7 @@ class ITObject(models.Model):
     name = models.CharField(max_length=100)
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_itobject', 'View IT Object'),
                        ('manage_itobject', 'Manage IT Object'), )
 
@@ -64,6 +68,7 @@ class Newsletter(models.Model):
     name = models.CharField(max_length=100)
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_newsletter', 'View Newsletter'),
                        ('send_newsletter', 'Send Newsletter'), )
 
@@ -76,6 +81,7 @@ Signals kwargs example with subclass
 class ProjectGroup(Group):
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_projectgroup', 'View Project Group'), )
 
     class GroupsManagerMeta:
@@ -86,6 +92,7 @@ class ProjectGroup(Group):
 class ProjectMember(Member):
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_projectmember', 'View Project Member'), )
 
 
@@ -142,6 +149,7 @@ class Site(models.Model):
     name = models.CharField(max_length=100)
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_site', 'View site'),
                        ('sell_site', 'Sell site'), )
 
@@ -252,6 +260,7 @@ class Pipeline(models.Model):
     name = models.CharField(max_length=100)
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_pipeline', 'View Pipeline'), )
 
 
@@ -365,6 +374,7 @@ class CloudPlatform(models.Model):
     name = models.CharField(max_length=100)
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_cloudplatform', 'View Cloud Platform'), )
 
 
@@ -372,6 +382,7 @@ class SurfaceProduct(models.Model):
     name = models.CharField(max_length=100)
 
     class Meta:
+        default_permissions = ('add', 'change', 'delete')
         permissions = (('view_surfaceproduct', 'View Surface Product'), )
 
 

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -7,7 +7,6 @@ https://docs.djangoproject.com/en/1.7/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.7/ref/settings/
 """
-from distutils.version import StrictVersion
 import os
 
 import django
@@ -51,25 +50,16 @@ INSTALLED_APPS = (
     'testproject',
 )
 
-if StrictVersion(django.get_version()) >= StrictVersion('2.0'):
-    MIDDLEWARE = (
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    )
-else:
-    MIDDLEWARE_CLASSES = (
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    )
+MIDDLEWARE = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+MIDDLEWARE_CLASSES = MIDDLEWARE
 
 # django-guardian required settings
 AUTHENTICATION_BACKENDS = (
@@ -116,19 +106,19 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 SESSION_COOKIE_NAME = "testproject"
 LOGIN_URL = '/admin/login/'
 
-if StrictVersion(django.get_version()) >= StrictVersion('2.0'):
-    TEMPLATES = [
-        {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'DIRS': [],
-            'APP_DIRS': True,
-            'OPTIONS': {
-                'context_processors': [
-                    'django.contrib.auth.context_processors.auth'                
-                ]
-            },
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                 'django.contrib.auth.context_processors.auth',
+                 'django.contrib.messages.context_processors.messages',
+	     ]
         },
-    ]
+    },
+]
 
 # Uncomment for testing application settings
 

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,5 +1,3 @@
-from distutils.version import StrictVersion
-
 import django
 from django.conf import settings
 from django.conf.urls import include, url
@@ -8,7 +6,7 @@ from django.contrib import admin
 
 from testproject import views
 
-if StrictVersion(django.get_version()) >= StrictVersion('1.9'):
+if django.VERSION >= (1, 9, 0):
     urlpatterns = [
         url(r'^admin/', admin.site.urls),
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,38 @@
+[tox]
+envlist =
+    {py27,py34,py35}-django{18,19,110,111}-mptt090-guardian14-jsonfield,
+    {py35,py36,py37}-django111-mptt0100-guardian14-jsonfield,
+    {py35,py36,py37}-django20-mptt0100-guardian14-jsonfield,
+    {py35,py36,py37}-django21-mptt0100-guardian21-jsonfield,
+    {py35,py36,py37}-django22-mptt0100-guardian21-jsonfield,
+    {py36,py37,py38}-django30-mptt0100-guardian21-jsonfield2,
+
+[testenv]
+commands =
+    pip freeze
+    coverage run testproject/manage.py test testproject groups_manager
+
+deps =
+    django18: django==1.8.*
+    django19: django==1.9.*
+    django110: django==1.10.*
+    django111: django==1.11.*
+    django20: django==2.0.*
+    django21: django==2.1.*
+    django22: django==2.2.*
+    django30: django>=3.0a1,<3.1
+
+    mptt090: django-mptt==0.9.0
+    mptt0100: django-mptt==0.10.0
+
+    guardian14: django-guardian==1.4.*
+    guardian21: django-guardian==2.1.*
+
+    jsonfield: jsonfield
+    jsonfield2: jsonfield2
+
+    awesome-slugify
+    coverage
+    coveralls
+    django-braces
+    django-extensions


### PR DESCRIPTION
Here I have added support for the upcoming Django 3.0. While testing I added a tox configuration which is also reused on travis. I've done my best to keep the support back to Django 1.8 and Python 2.7 but I think it might be worth to consider dropping support for Django 1.8, 1.9, 1.10 and 2.0, as well as Python 2.7 since the Django versions have already lost support and Python 2.7 will do the same January 1st 2020 