### PR TITLE
Replace jsonfield2 with jsonfield 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Online documentation is available at http://django-groups-manager.readthedocs.or
     - Python >= 3.5
     - Django >= 2
     - django-guardian for user permissions
+    - jsonfield == 3.1.0
 
 For older versions of Python or Django, please look at 0.6.2 version.
 

--- a/testproject/requirements.txt
+++ b/testproject/requirements.txt
@@ -2,6 +2,6 @@ awesome-slugify
 django>=2
 django-guardian
 django-mptt
-jsonfield2
+jsonfield
 
 django-extensions

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
     {py35,py36,py37}-django20-mptt0100-guardian14-jsonfield,
     {py35,py36,py37}-django21-mptt0100-guardian21-jsonfield,
     {py35,py36,py37}-django22-mptt0100-guardian21-jsonfield,
-    {py36,py37,py38}-django30-mptt0100-jsonfield2,
-    {py36,py37,py38}-django30-mptt0100-guardian21-jsonfield2,
+    {py36,py37,py38}-django30-mptt0100-jsonfield,
+    {py36,py37,py38}-django30-mptt0100-guardian21-jsonfield,
 
 [testenv]
 commands =
@@ -24,7 +24,6 @@ deps =
     guardian21: django-guardian==2.1.*
 
     jsonfield: jsonfield
-    jsonfield2: jsonfield2
 
     awesome-slugify
     coverage


### PR DESCRIPTION
Jsonfield2 was recently deprecated and merged into the latest version of jsonfield package. (The beginning of March)
https://github.com/rpkilby/jsonfield