### PR TITLE
Fix documentation

### DIFF
--- a/docs/source/custom_member.rst
+++ b/docs/source/custom_member.rst
@@ -16,8 +16,8 @@ The value of the attribute is in ``<application>.<model_name>`` form.
 
     class Organization(Group):
     
-        class GroupsModelMeta:
-            model_name = 'myApp.OrganizationMember'
+        class GroupsManagerMeta:
+            member_model = 'myApp.OrganizationMember'
     
 
     class OrganizationMember(Member):


### PR DESCRIPTION
Hi, I think I've found an error in the Documentation. My goal was to check if a custom member CustomMember was in the CustomGroup members collection. Reading the code I found that GroupsManagerMeta worked while GroupsModelMeta didn't. 